### PR TITLE
Update to the way admin roles are processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A configuration file `config.json` is included with the package. Use the followi
 |pool_codebase|The codebase your Garlicoin Pool is running on. Currently only `NOMP` is supported.|
 |pool_api_url|The URL to your pool's API|
 |prefix|Define the prefix you would prefer for bot commands (Default is `!`)|
-|bot_admin_roles|Any roles (separated by spaces) you would like to have access to Bot Admin Commands|
+|bot_admin_roles|Any roles, separated by commas (`,`), you would like to have access to Bot Admin Commands|
 
 ## Execution
 Use `node bot.js` within the deployment directory to start the bot. If all is configured correctly you should see it join your server. You can then go about managing roles. 

--- a/bot.js
+++ b/bot.js
@@ -49,7 +49,7 @@ discordClient.on("ready", () => {
 
     // Populate the botAdminRoles array
     consoleLog(`Setting admin roles to ${config.bot_admin_roles}`);
-    botAdminRoles = config.bot_admin_roles.split(" ");
+    botAdminRoles = config.bot_admin_roles.split(",");
 
     // Poll the pool's API for the stats JSON data, then update the poolBlockData array
     consoleLog(`Getting initial pool API data`);


### PR DESCRIPTION
Old method split based on a space but that failed to account for roles
with spaces in them. Going with comma as a seperator.